### PR TITLE
Replace binary images with SVG placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # customer_maintenance
-Customer maintenance encompasses activities like adding new customers to a database, updating their information, and removing outdated records
+Customer maintenance encompasses activities like adding new customers to a database, updating their information, and removing outdated records.
+
+This repository contains placeholder SVG icons in `customer-app/public` to avoid binary image files. These small text-based assets can be replaced with your own images or served from a remote URL if needed.

--- a/customer-app/public/favicon.svg
+++ b/customer-app/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <rect width="32" height="32" fill="#ccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14">F</text>
+</svg>

--- a/customer-app/public/logo192.svg
+++ b/customer-app/public/logo192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192">
+  <rect width="192" height="192" fill="#ccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24">192</text>
+</svg>

--- a/customer-app/public/logo512.svg
+++ b/customer-app/public/logo512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512">
+  <rect width="512" height="512" fill="#ccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="48">512</text>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder SVG icons in `customer-app/public`
- document placeholder icons in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409bdc5308832d9e573b5388f6c5d8