### PR TITLE
Add e2e http tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ npm run start
 ```
 
 The API will be available at `http://localhost:3001`.
+
+### E2E Tests
+
+Sample `.http` files for testing the API can be found in `customer-api/e2e/`.
+These files can be executed using an HTTP client extension such as the VS Code
+REST Client.

--- a/customer-api/e2e/create-customer.http
+++ b/customer-api/e2e/create-customer.http
@@ -1,0 +1,15 @@
+# App: Customer CRUD Application
+# Package: customer-api
+# File: e2e/create-customer.http
+# Version: 2.0.31
+# Author: Bobwares
+# Date: 2025-06-04 21:50:39 UTC
+# Description: E2E test for creating a customer.
+#
+POST http://localhost:3001/customers
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "email": "alice@example.com"
+}

--- a/customer-api/e2e/delete-customer.http
+++ b/customer-api/e2e/delete-customer.http
@@ -1,0 +1,9 @@
+# App: Customer CRUD Application
+# Package: customer-api
+# File: e2e/delete-customer.http
+# Version: 2.0.31
+# Author: Bobwares
+# Date: 2025-06-04 21:50:39 UTC
+# Description: E2E test for deleting a customer.
+#
+DELETE http://localhost:3001/customers/1

--- a/customer-api/e2e/get-customer.http
+++ b/customer-api/e2e/get-customer.http
@@ -1,0 +1,9 @@
+# App: Customer CRUD Application
+# Package: customer-api
+# File: e2e/get-customer.http
+# Version: 2.0.31
+# Author: Bobwares
+# Date: 2025-06-04 21:50:39 UTC
+# Description: E2E test for retrieving a single customer.
+#
+GET http://localhost:3001/customers/1

--- a/customer-api/e2e/list-customers.http
+++ b/customer-api/e2e/list-customers.http
@@ -1,0 +1,9 @@
+# App: Customer CRUD Application
+# Package: customer-api
+# File: e2e/list-customers.http
+# Version: 2.0.31
+# Author: Bobwares
+# Date: 2025-06-04 21:50:39 UTC
+# Description: E2E test for retrieving all customers.
+#
+GET http://localhost:3001/customers

--- a/customer-api/e2e/update-customer.http
+++ b/customer-api/e2e/update-customer.http
@@ -1,0 +1,14 @@
+# App: Customer CRUD Application
+# Package: customer-api
+# File: e2e/update-customer.http
+# Version: 2.0.31
+# Author: Bobwares
+# Date: 2025-06-04 21:50:39 UTC
+# Description: E2E test for updating a customer.
+#
+PATCH http://localhost:3001/customers/1
+Content-Type: application/json
+
+{
+  "name": "Alice Updated"
+}

--- a/customer-api/src/app.module.ts
+++ b/customer-api/src/app.module.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/app.module.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: Root application module.

--- a/customer-api/src/customers/customers.controller.ts
+++ b/customer-api/src/customers/customers.controller.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customers.controller.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: HTTP controller for customer routes.

--- a/customer-api/src/customers/customers.module.ts
+++ b/customer-api/src/customers/customers.module.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customers.module.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: Module defining the customers feature.

--- a/customer-api/src/customers/customers.service.ts
+++ b/customer-api/src/customers/customers.service.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customers.service.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: Business logic for managing customers.

--- a/customer-api/src/customers/dto/create-customer.dto.ts
+++ b/customer-api/src/customers/dto/create-customer.dto.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/dto/create-customer.dto.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: DTO for creating a customer.

--- a/customer-api/src/customers/dto/update-customer.dto.ts
+++ b/customer-api/src/customers/dto/update-customer.dto.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/dto/update-customer.dto.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: DTO for updating a customer.

--- a/customer-api/src/main.ts
+++ b/customer-api/src/main.ts
@@ -1,7 +1,7 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/main.ts
-// Version: 2.0.30
+// Version: 2.0.31
 // Author: Bobwares
 // Date: 2025-06-04 21:28:20 UTC
 // Description: Bootstraps the NestJS application.

--- a/version.md
+++ b/version.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 2.0.31 - 2025-06-04
+- Added .http e2e tests in `customer-api/e2e/`.
+- Bumped metadata version headers.
+
 ## 2.0.30 - 2025-06-04
 - Added backend NestJS CRUD API in `customer-api/`.
 - Updated README with backend instructions.


### PR DESCRIPTION
## Summary
- create e2e directory with `.http` requests
- reference e2e tests in README
- bump metadata version headers to 2.0.31
- document version 2.0.31

## Testing
- `npx tsc -p customer-api/tsconfig.json --noEmit`
- `npx tsc -p customer-app/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6840bf5d6cfc832db709c3243e49f839