### PR TITLE
Add email and timestamp fields

### DIFF
--- a/customer-api/e2e/create-customer.http
+++ b/customer-api/e2e/create-customer.http
@@ -1,9 +1,9 @@
 # App: Customer CRUD Application
 # Package: customer-api
 # File: e2e/create-customer.http
-# Version: 2.0.35
+# Version: 2.0.36
 # Author: Bobwares
-# Date: 2025-06-05 01:24:16 UTC
+# Date: 2025-06-05 01:48:55 UTC
 # Description: E2E test for creating a customer.
 #
 POST http://localhost:3001/customers
@@ -13,6 +13,7 @@ Content-Type: application/json
   "first": "Alice",
   "last": "Smith",
   "age": 30,
+  "email": "alice.smith@example.com",
   "address": {
     "street": "123 Main",
     "city": "Anytown",

--- a/customer-api/e2e/delete-customer.http
+++ b/customer-api/e2e/delete-customer.http
@@ -1,9 +1,9 @@
 # App: Customer CRUD Application
 # Package: customer-api
 # File: e2e/delete-customer.http
-# Version: 2.0.34
+# Version: 2.0.36
 # Author: Bobwares
-# Date: 2025-06-05 00:14:14 UTC
+# Date: 2025-06-05 01:49:28 UTC
 # Description: E2E test for deleting a customer.
 #
 DELETE http://localhost:3001/customers/1

--- a/customer-api/e2e/get-customer.http
+++ b/customer-api/e2e/get-customer.http
@@ -1,9 +1,9 @@
 # App: Customer CRUD Application
 # Package: customer-api
 # File: e2e/get-customer.http
-# Version: 2.0.34
+# Version: 2.0.36
 # Author: Bobwares
-# Date: 2025-06-05 00:14:14 UTC
+# Date: 2025-06-05 01:49:22 UTC
 # Description: E2E test for retrieving a single customer.
 #
 GET http://localhost:3001/customers/1

--- a/customer-api/e2e/list-customers.http
+++ b/customer-api/e2e/list-customers.http
@@ -1,9 +1,9 @@
 # App: Customer CRUD Application
 # Package: customer-api
 # File: e2e/list-customers.http
-# Version: 2.0.34
+# Version: 2.0.36
 # Author: Bobwares
-# Date: 2025-06-05 00:14:14 UTC
+# Date: 2025-06-05 01:49:13 UTC
 # Description: E2E test for retrieving all customers.
 #
 GET http://localhost:3001/customers

--- a/customer-api/e2e/update-customer.http
+++ b/customer-api/e2e/update-customer.http
@@ -1,9 +1,9 @@
 # App: Customer CRUD Application
 # Package: customer-api
 # File: e2e/update-customer.http
-# Version: 2.0.35
+# Version: 2.0.36
 # Author: Bobwares
-# Date: 2025-06-05 01:24:29 UTC
+# Date: 2025-06-05 01:49:04 UTC
 # Description: E2E test for updating a customer.
 #
 PATCH http://localhost:3001/customers/1
@@ -11,6 +11,7 @@ Content-Type: application/json
 
 {
   "age": 31,
+  "email": "updated@example.com",
   "address": {
     "city": "New City"
   }

--- a/customer-api/src/app.module.ts
+++ b/customer-api/src/app.module.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/app.module.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:22:19 UTC
+// Date: 2025-06-05 01:48:44 UTC
 // Description: Root application module.
 //
 import { Module } from '@nestjs/common';

--- a/customer-api/src/customers/customer.entity.ts
+++ b/customer-api/src/customers/customer.entity.ts
@@ -1,12 +1,18 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customer.entity.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:22:37 UTC
-// Description: TypeORM entity representing a customer.
+// Date: 2025-06-05 01:47:43 UTC
+// Description: TypeORM entity representing a customer with email and timestamps.
 //
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity()
 export class Customer {
@@ -23,6 +29,9 @@ export class Customer {
   age!: number;
 
   @Column()
+  email!: string;
+
+  @Column()
   street!: string;
 
   @Column()
@@ -33,4 +42,10 @@ export class Customer {
 
   @Column()
   zipcode!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
 }

--- a/customer-api/src/customers/customers.controller.ts
+++ b/customer-api/src/customers/customers.controller.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customers.controller.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:24:00 UTC
+// Date: 2025-06-05 01:48:32 UTC
 // Description: HTTP controller for customer routes.
 //
 import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';

--- a/customer-api/src/customers/customers.module.ts
+++ b/customer-api/src/customers/customers.module.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customers.module.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:24:07 UTC
+// Date: 2025-06-05 01:48:38 UTC
 // Description: Module defining the customers feature.
 //
 import { Module } from '@nestjs/common';

--- a/customer-api/src/customers/customers.service.ts
+++ b/customer-api/src/customers/customers.service.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/customers.service.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:23:52 UTC
+// Date: 2025-06-05 01:48:26 UTC
 // Description: Business logic for managing customers.
 //
 import { Injectable, NotFoundException } from '@nestjs/common';
@@ -22,12 +22,14 @@ export class CustomersService {
     first: string;
     last: string;
     age: number;
+    email: string;
     address: { street: string; city: string; state: string; zipcode: string };
   }): Promise<Customer> {
     const customer = this.repo.create({
       first: data.first,
       last: data.last,
       age: data.age,
+      email: data.email,
       street: data.address.street,
       city: data.address.city,
       state: data.address.state,
@@ -54,6 +56,7 @@ export class CustomersService {
       first?: string;
       last?: string;
       age?: number;
+      email?: string;
       address?: {
         street?: string;
         city?: string;
@@ -71,6 +74,9 @@ export class CustomersService {
     }
     if (data.age !== undefined) {
       customer.age = data.age;
+    }
+    if (data.email !== undefined) {
+      customer.email = data.email;
     }
     if (data.address) {
       if (data.address.street !== undefined) {

--- a/customer-api/src/customers/dto/create-customer.dto.ts
+++ b/customer-api/src/customers/dto/create-customer.dto.ts
@@ -1,14 +1,15 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/dto/create-customer.dto.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:23:21 UTC
+// Date: 2025-06-05 01:48:04 UTC
 // Description: DTO for creating a customer.
 //
 import {
   IsInt,
   IsString,
+  IsEmail,
   Length,
   Matches,
   Min,
@@ -22,6 +23,9 @@ export class CreateCustomerDto {
 
   @IsString()
   last!: string;
+
+  @IsEmail()
+  email!: string;
 
   @IsInt()
   @Min(0)

--- a/customer-api/src/customers/dto/update-customer.dto.ts
+++ b/customer-api/src/customers/dto/update-customer.dto.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/dto/update-customer.dto.ts
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:23:26 UTC
+// Date: 2025-06-05 01:48:10 UTC
 // Description: DTO for updating a customer.
 //
 import { PartialType } from '@nestjs/mapped-types';

--- a/customer-api/src/main.ts
+++ b/customer-api/src/main.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/main.ts
-// Version: 2.0.34
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 00:14:14 UTC
+// Date: 2025-06-05 01:48:49 UTC
 // Description: Bootstraps the NestJS application.
 //
 import { NestFactory } from '@nestjs/core';

--- a/customer-app/src/app/customers/page.tsx
+++ b/customer-app/src/app/customers/page.tsx
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-app
 // File: src/app/customers/page.tsx
-// Version: 2.0.35
+// Version: 2.0.36
 // Author: Bobwares
-// Date: 2025-06-05 01:26:26 UTC
+// Date: 2025-06-05 01:49:58 UTC
 // Description: Customer maintenance page using customer-api backend.
 //
 "use client";
@@ -22,6 +22,7 @@ interface Customer {
   first: string;
   last: string;
   age: number;
+  email: string;
   address: Address;
 }
 
@@ -34,6 +35,7 @@ export default function CustomersPage() {
     first: '',
     last: '',
     age: 0,
+    email: '',
     address: { street: '', city: '', state: '', zipcode: '' },
   });
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -122,6 +124,15 @@ export default function CustomersPage() {
           />
         </label>
         <label>
+          Email
+          <input
+            type="email"
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+            required
+          />
+        </label>
+        <label>
           Age
           <input
             type="number"
@@ -184,6 +195,7 @@ export default function CustomersPage() {
             <tr>
               <th>First</th>
               <th>Last</th>
+              <th>Email</th>
               <th>Age</th>
               <th>Street</th>
               <th>City</th>
@@ -197,6 +209,7 @@ export default function CustomersPage() {
               <tr key={c.id}>
                 <td>{c.first}</td>
                 <td>{c.last}</td>
+                <td>{c.email}</td>
                 <td>{c.age}</td>
                 <td>{c.address.street}</td>
                 <td>{c.address.city}</td>

--- a/schema/customer_schema.json
+++ b/schema/customer_schema.json
@@ -4,13 +4,17 @@
   "type": "array",
   "items": {
     "type": "object",
-    "required": ["first", "last", "age", "address"],
+    "required": ["first", "last", "age", "email", "address"],
     "properties": {
       "first": {
         "type": "string"
       },
       "last": {
         "type": "string"
+      },
+      "email": {
+        "type": "string",
+        "format": "email"
       },
       "age": {
         "type": "integer",
@@ -20,25 +24,16 @@
         "type": "object",
         "required": ["street", "city", "state", "zipcode"],
         "properties": {
-          "street": {
-            "type": "string"
-          },
-          "city": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string",
-            "minLength": 2,
-            "maxLength": 2
-          },
-          "zipcode": {
-            "type": "string",
-            "pattern": "^\\d{5}$"
-          }
+          "street": { "type": "string" },
+          "city": { "type": "string" },
+          "state": { "type": "string", "minLength": 2, "maxLength": 2 },
+          "zipcode": { "type": "string", "pattern": "^\\d{5}$" }
         },
         "additionalProperties": false
-      }
+      },
+      "createdAt": { "type": "string", "format": "date-time" },
+      "updatedAt": { "type": "string", "format": "date-time" }
     },
     "additionalProperties": false
   }
-}
+ }

--- a/schema/customers.json
+++ b/schema/customers.json
@@ -3,6 +3,9 @@
     "first": "John",
     "last": "Doe",
     "age": 30,
+    "email": "john.doe@example.com",
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:00:00Z",
     "address": {
       "street": "123 Main Street",
       "city": "Anytown",
@@ -14,6 +17,9 @@
     "first": "Jane",
     "last": "Smith",
     "age": 25,
+    "email": "jane.smith@example.com",
+    "createdAt": "2024-01-02T00:00:00Z",
+    "updatedAt": "2024-01-02T00:00:00Z",
     "address": {
       "street": "456 Elm Street",
       "city": "Los Angeles",
@@ -25,6 +31,9 @@
     "first": "Mary",
     "last": "Williams",
     "age": 40,
+    "email": "mary.williams@example.com",
+    "createdAt": "2024-01-03T00:00:00Z",
+    "updatedAt": "2024-01-03T00:00:00Z",
     "address": {
       "street": "789 Oak Street",
       "city": "San Francisco",
@@ -36,6 +45,9 @@
     "first": "Peter",
     "last": "Jones",
     "age": 35,
+    "email": "peter.jones@example.com",
+    "createdAt": "2024-01-04T00:00:00Z",
+    "updatedAt": "2024-01-04T00:00:00Z",
     "address": {
       "street": "101 Pine Street",
       "city": "San Diego",
@@ -47,6 +59,9 @@
     "first": "Susan",
     "last": "Brown",
     "age": 20,
+    "email": "susan.brown@example.com",
+    "createdAt": "2024-01-05T00:00:00Z",
+    "updatedAt": "2024-01-05T00:00:00Z",
     "address": {
       "street": "1234 Main Street",
       "city": "Fremont",
@@ -58,6 +73,9 @@
     "first": "David",
     "last": "Green",
     "age": 50,
+    "email": "david.green@example.com",
+    "createdAt": "2024-01-06T00:00:00Z",
+    "updatedAt": "2024-01-06T00:00:00Z",
     "address": {
       "street": "456 Elm Street",
       "city": "Oakland",
@@ -69,6 +87,9 @@
     "first": "Elizabeth",
     "last": "White",
     "age": 60,
+    "email": "elizabeth.white@example.com",
+    "createdAt": "2024-01-07T00:00:00Z",
+    "updatedAt": "2024-01-07T00:00:00Z",
     "address": {
       "street": "789 Oak Street",
       "city": "Berkeley",
@@ -80,6 +101,9 @@
     "first": "Michael",
     "last": "Black",
     "age": 70,
+    "email": "michael.black@example.com",
+    "createdAt": "2024-01-08T00:00:00Z",
+    "updatedAt": "2024-01-08T00:00:00Z",
     "address": {
       "street": "101 Pine Street",
       "city": "San Jose",
@@ -91,6 +115,9 @@
     "first": "Sarah",
     "last": "Blue",
     "age": 80,
+    "email": "sarah.blue@example.com",
+    "createdAt": "2024-01-09T00:00:00Z",
+    "updatedAt": "2024-01-09T00:00:00Z",
     "address": {
       "street": "1234 Main Street",
       "city": "Santa Cruz",

--- a/version.md
+++ b/version.md
@@ -1,4 +1,8 @@
 # Version History
+## 2.0.36 - 2025-06-05
+- Added email and timestamp fields to customer schema and database entity.
+- Updated DTOs, service, frontend, and test files.
+- Bumped metadata version headers.
 ## 2.0.35 - 2025-06-05
 - Removed Person module and schema; updated customer schema to match customer_schema.json.
 - Bumped metadata version headers.


### PR DESCRIPTION
## Summary
- add email, createdAt, updatedAt fields to customer schema and entity
- update DTOs, service, controller, and module
- extend frontend with email field
- adjust sample data and e2e tests
- bump metadata version headers

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840f688bdd0832da1130cc1d0ae7d9d