### PR TITLE
Implement full state names and expand zipcode field

### DIFF
--- a/customer-api/src/customers/dto/address.dto.ts
+++ b/customer-api/src/customers/dto/address.dto.ts
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-api
 // File: src/customers/dto/address.dto.ts
-// Version: 2.0.41
+// Version: 2.0.43
 // Author: Bobwares
-// Date: 2025-06-05 06:37:28 UTC
+// Date: 2025-06-05 07:09:46 UTC
 // Description: Data transfer object for customer addresses.
 //
 import { IsString, Length, Matches } from 'class-validator';
@@ -16,10 +16,10 @@ export class AddressDto {
   city!: string;
 
   @IsString()
-  @Length(2, 2)
+  @Length(2, 30)
   state!: string;
 
   @IsString()
-  @Matches(/^\d{5}$/)
+  @Matches(/^\d{5}(-\d{4})?$/)
   zipcode!: string;
 }

--- a/customer-app/src/app/customers/page.module.css
+++ b/customer-app/src/app/customers/page.module.css
@@ -2,9 +2,9 @@
 # App: Customer CRUD Application
 # Package: customer-app
 # File: src/app/customers/page.module.css
-# Version: 2.0.42
+# Version: 2.0.43
 # Author: Bobwares
-# Date: 2025-06-05 06:59:52 UTC
+# Date: 2025-06-05 07:09:36 UTC
 # Description: CSS styles for the customer maintenance page.
 #
 */
@@ -41,7 +41,16 @@
 }
 
 .zipInput {
-  width: 6ch;
+  width: 12ch;
+}
+
+.stateSelect {
+  width: 16ch;
+}
+
+.row {
+  display: flex;
+  gap: 1rem;
 }
 
 .col {

--- a/customer-app/src/app/customers/page.tsx
+++ b/customer-app/src/app/customers/page.tsx
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-app
 // File: src/app/customers/page.tsx
-// Version: 2.0.42
+// Version: 2.0.43
 // Author: Bobwares
-// Date: 2025-06-05 06:59:52 UTC
+// Date: 2025-06-05 07:09:10 UTC
 // Description: Customer maintenance page using customer-api backend.
 //
 "use client";
@@ -11,11 +11,56 @@ import { useEffect, useState } from 'react';
 import styles from './page.module.css';
 
 const STATES = [
-  'AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA',
-  'HI','ID','IL','IN','IA','KS','KY','LA','ME','MD',
-  'MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ',
-  'NM','NY','NC','ND','OH','OK','OR','PA','RI','SC',
-  'SD','TN','TX','UT','VT','VA','WA','WV','WI','WY',
+  'Alabama',
+  'Alaska',
+  'Arizona',
+  'Arkansas',
+  'California',
+  'Colorado',
+  'Connecticut',
+  'Delaware',
+  'Florida',
+  'Georgia',
+  'Hawaii',
+  'Idaho',
+  'Illinois',
+  'Indiana',
+  'Iowa',
+  'Kansas',
+  'Kentucky',
+  'Louisiana',
+  'Maine',
+  'Maryland',
+  'Massachusetts',
+  'Michigan',
+  'Minnesota',
+  'Mississippi',
+  'Missouri',
+  'Montana',
+  'Nebraska',
+  'Nevada',
+  'New Hampshire',
+  'New Jersey',
+  'New Mexico',
+  'New York',
+  'North Carolina',
+  'North Dakota',
+  'Ohio',
+  'Oklahoma',
+  'Oregon',
+  'Pennsylvania',
+  'Rhode Island',
+  'South Carolina',
+  'South Dakota',
+  'Tennessee',
+  'Texas',
+  'Utah',
+  'Vermont',
+  'Virginia',
+  'Washington',
+  'West Virginia',
+  'Wisconsin',
+  'Wyoming',
 ];
 
 interface Address {
@@ -175,31 +220,34 @@ export default function CustomersPage() {
               maxLength={30}
             />
           </label>
-          <label>
-            State
-            <select
-              value={form.address?.state ?? ''}
-              onChange={(e) => setAddress('state', e.target.value)}
-              required
-            >
-              <option value="">Select...</option>
-              {STATES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Zipcode
-            <input
-              value={form.address?.zipcode ?? ''}
-              onChange={(e) => setAddress('zipcode', e.target.value)}
-              required
-              maxLength={5}
-              className={styles.zipInput}
-            />
-          </label>
+          <div className={styles.row}>
+            <label>
+              State
+              <select
+                className={styles.stateSelect}
+                value={form.address?.state ?? ''}
+                onChange={(e) => setAddress('state', e.target.value)}
+                required
+              >
+                <option value="">Select...</option>
+                {STATES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Zipcode
+              <input
+                value={form.address?.zipcode ?? ''}
+                onChange={(e) => setAddress('zipcode', e.target.value)}
+                required
+                maxLength={10}
+                className={styles.zipInput}
+              />
+            </label>
+          </div>
         </div>
         <div className={styles.formButtons}>
           <button type="submit" className={styles.button}>

--- a/schema/customer_schema.json
+++ b/schema/customer_schema.json
@@ -26,8 +26,8 @@
         "properties": {
           "street": { "type": "string" },
           "city": { "type": "string" },
-          "state": { "type": "string", "minLength": 2, "maxLength": 2 },
-          "zipcode": { "type": "string", "pattern": "^\\d{5}$" }
+          "state": { "type": "string", "minLength": 2, "maxLength": 30 },
+          "zipcode": { "type": "string", "pattern": "^\\d{5}(-\\d{4})?$" }
         },
         "additionalProperties": false
       },

--- a/schema/customers.json
+++ b/schema/customers.json
@@ -9,7 +9,7 @@
     "address": {
       "street": "123 Main Street",
       "city": "Anytown",
-      "state": "CA",
+      "state": "California",
       "zipcode": "12345"
     }
   },
@@ -23,7 +23,7 @@
     "address": {
       "street": "456 Elm Street",
       "city": "Los Angeles",
-      "state": "CA",
+      "state": "California",
       "zipcode": "56789"
     }
   },
@@ -37,7 +37,7 @@
     "address": {
       "street": "789 Oak Street",
       "city": "San Francisco",
-      "state": "CA",
+      "state": "California",
       "zipcode": "90123"
     }
   },
@@ -51,7 +51,7 @@
     "address": {
       "street": "101 Pine Street",
       "city": "San Diego",
-      "state": "CA",
+      "state": "California",
       "zipcode": "10101"
     }
   },
@@ -65,7 +65,7 @@
     "address": {
       "street": "1234 Main Street",
       "city": "Fremont",
-      "state": "CA",
+      "state": "California",
       "zipcode": "94538"
     }
   },
@@ -79,7 +79,7 @@
     "address": {
       "street": "456 Elm Street",
       "city": "Oakland",
-      "state": "CA",
+      "state": "California",
       "zipcode": "94607"
     }
   },
@@ -93,7 +93,7 @@
     "address": {
       "street": "789 Oak Street",
       "city": "Berkeley",
-      "state": "CA",
+      "state": "California",
       "zipcode": "94704"
     }
   },
@@ -107,7 +107,7 @@
     "address": {
       "street": "101 Pine Street",
       "city": "San Jose",
-      "state": "CA",
+      "state": "California",
       "zipcode": "95113"
     }
   },
@@ -121,7 +121,7 @@
     "address": {
       "street": "1234 Main Street",
       "city": "Santa Cruz",
-      "state": "CA",
+      "state": "California",
       "zipcode": "95060"
     }
   }

--- a/version.md
+++ b/version.md
@@ -1,4 +1,10 @@
 # Version History
+## 2.0.43 - 2025-06-05
+- Display full state names in dropdown and table.
+- Allow 10-character zip codes and place state and zip on one row.
+- Adjust dropdown width for longest state name.
+- Updated validation schema for new formats.
+
 ## 2.0.42 - 2025-06-05
 - Added dropdown list of US states on customer form.
 - Limited text input fields to 30 characters and zipcode to 5.


### PR DESCRIPTION
## Summary
- display state names instead of abbreviations
- size state dropdown for longest name and show state/zip on one row
- allow zip codes up to 10 characters
- update validation schema and sample data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841423fe294832d98c2c6638361d29c