### PR TITLE
Implement two-page customer UI

### DIFF
--- a/customer-app/src/app/customers/form/page.tsx
+++ b/customer-app/src/app/customers/form/page.tsx
@@ -1,0 +1,143 @@
+// App: Customer CRUD Application
+// Package: customer-app
+// File: src/app/customers/form/page.tsx
+// Version: 2.0.46
+// Author: Bobwares
+// Date: 2025-06-05 07:30:00 UTC
+// Description: Customer form page for adding or editing records.
+//
+"use client";
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import styles from '../page.module.css';
+
+const STATES = [
+  'Alabama','Alaska','Arizona','Arkansas','California','Colorado','Connecticut','Delaware','Florida','Georgia','Hawaii','Idaho','Illinois','Indiana','Iowa','Kansas','Kentucky','Louisiana','Maine','Maryland','Massachusetts','Michigan','Minnesota','Mississippi','Missouri','Montana','Nebraska','Nevada','New Hampshire','New Jersey','New Mexico','New York','North Carolina','North Dakota','Ohio','Oklahoma','Oregon','Pennsylvania','Rhode Island','South Carolina','South Dakota','Tennessee','Texas','Utah','Vermont','Virginia','Washington','West Virginia','Wisconsin','Wyoming'
+];
+
+interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zipcode: string;
+}
+
+interface Customer {
+  id: number;
+  first: string;
+  last: string;
+  age: number;
+  email: string;
+  address?: Address;
+}
+
+const API_URL = 'http://localhost:3001/customers';
+
+export default function CustomerFormPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const idParam = searchParams.get('id');
+  const editingId = idParam ? Number(idParam) : null;
+
+  const [form, setForm] = useState<Customer>({
+    id: 0,
+    first: '',
+    last: '',
+    age: 0,
+    email: '',
+    address: { street: '', city: '', state: '', zipcode: '' },
+  });
+
+  useEffect(() => {
+    if (editingId !== null) {
+      fetch(`${API_URL}/${editingId}`)
+        .then((res) => res.json())
+        .then((data) => setForm({ ...data, address: data.address ?? { street: '', city: '', state: '', zipcode: '' } }));
+    }
+  }, [editingId]);
+
+  const setAddress = (key: keyof Address, value: string) => {
+    setForm((prev) => ({
+      ...prev,
+      address: { ...(prev.address || { street: '', city: '', state: '', zipcode: '' }), [key]: value },
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = { ...form };
+    if (editingId === null) {
+      await fetch(API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await fetch(`${API_URL}/${editingId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+    router.push('/customers');
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1>{editingId === null ? 'Add Customer' : 'Edit Customer'}</h1>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.col}>
+          <label>
+            First
+            <input value={form.first} onChange={(e) => setForm({ ...form, first: e.target.value })} required maxLength={30} />
+          </label>
+          <label>
+            Last
+            <input value={form.last} onChange={(e) => setForm({ ...form, last: e.target.value })} required maxLength={30} />
+          </label>
+          <label>
+            Email
+            <input type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required maxLength={30} />
+          </label>
+          <label>
+            Age
+            <input type="number" value={form.age} onChange={(e) => setForm({ ...form, age: Number(e.target.value) })} min={0} required />
+          </label>
+        </div>
+        <div className={styles.col}>
+          <label>
+            Street
+            <input value={form.address?.street ?? ''} onChange={(e) => setAddress('street', e.target.value)} required maxLength={30} />
+          </label>
+          <label>
+            City
+            <input value={form.address?.city ?? ''} onChange={(e) => setAddress('city', e.target.value)} required maxLength={30} />
+          </label>
+          <div className={styles.row}>
+            <label>
+              State
+              <select className={styles.stateSelect} value={form.address?.state ?? ''} onChange={(e) => setAddress('state', e.target.value)} required>
+                <option value="">Select...</option>
+                {STATES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Zipcode
+              <input value={form.address?.zipcode ?? ''} onChange={(e) => setAddress('zipcode', e.target.value)} required maxLength={10} className={styles.zipInput} />
+            </label>
+          </div>
+        </div>
+        <div className={styles.formButtons}>
+          <button type="submit" className={styles.button}>
+            {editingId === null ? 'Add' : 'Update'}
+          </button>
+          <button type="button" onClick={() => router.push('/customers')} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/customer-app/src/app/customers/page.module.css
+++ b/customer-app/src/app/customers/page.module.css
@@ -2,9 +2,9 @@
 # App: Customer CRUD Application
 # Package: customer-app
 # File: src/app/customers/page.module.css
-# Version: 2.0.45
+# Version: 2.0.46
 # Author: Bobwares
-# Date: 2025-06-05 07:21:35 UTC
+# Date: 2025-06-05 07:30:00 UTC
 # Description: CSS styles for the customer maintenance page.
 #
 */
@@ -86,6 +86,22 @@
   background-color: #e0e0e0;
 }
 
+.tableHeader {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.newButton {
+  background-color: #1e3a8a;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+}
+
+.newButton:hover {
+  background-color: #162d6a;
+}
+
 .tableContainer {
   background-color: #ffffff;
   border: 1px solid #ccc;
@@ -107,4 +123,8 @@
 
 .table th {
   cursor: pointer;
+}
+
+.actionButton {
+  margin-right: 0.5rem;
 }

--- a/customer-app/src/app/customers/page.tsx
+++ b/customer-app/src/app/customers/page.tsx
@@ -1,67 +1,16 @@
 // App: Customer CRUD Application
 // Package: customer-app
 // File: src/app/customers/page.tsx
-// Version: 2.0.45
+// Version: 2.0.46
 // Author: Bobwares
-// Date: 2025-06-05 07:21:35 UTC
-// Description: Customer maintenance page using customer-api backend.
+// Date: 2025-06-05 07:30:00 UTC
+// Description: Customer table page with navigation to form page.
 //
 "use client";
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import styles from './page.module.css';
-
-const STATES = [
-  'Alabama',
-  'Alaska',
-  'Arizona',
-  'Arkansas',
-  'California',
-  'Colorado',
-  'Connecticut',
-  'Delaware',
-  'Florida',
-  'Georgia',
-  'Hawaii',
-  'Idaho',
-  'Illinois',
-  'Indiana',
-  'Iowa',
-  'Kansas',
-  'Kentucky',
-  'Louisiana',
-  'Maine',
-  'Maryland',
-  'Massachusetts',
-  'Michigan',
-  'Minnesota',
-  'Mississippi',
-  'Missouri',
-  'Montana',
-  'Nebraska',
-  'Nevada',
-  'New Hampshire',
-  'New Jersey',
-  'New Mexico',
-  'New York',
-  'North Carolina',
-  'North Dakota',
-  'Ohio',
-  'Oklahoma',
-  'Oregon',
-  'Pennsylvania',
-  'Rhode Island',
-  'South Carolina',
-  'South Dakota',
-  'Tennessee',
-  'Texas',
-  'Utah',
-  'Vermont',
-  'Virginia',
-  'Washington',
-  'West Virginia',
-  'Wisconsin',
-  'Wyoming',
-];
 
 interface Address {
   street: string;
@@ -83,19 +32,11 @@ const API_URL = 'http://localhost:3001/customers';
 
 export default function CustomersPage() {
   const [customers, setCustomers] = useState<Customer[]>([]);
-  const [form, setForm] = useState<Customer>({
-    id: 0,
-    first: '',
-    last: '',
-    age: 0,
-    email: '',
-    address: { street: '', city: '', state: '', zipcode: '' },
-  });
-  const [editingId, setEditingId] = useState<number | null>(null);
   const [sortConfig, setSortConfig] = useState<{ key: string; direction: 'asc' | 'desc' }>({
     key: 'last',
     direction: 'asc',
   });
+  const router = useRouter();
 
   const loadCustomers = async () => {
     const res = await fetch(API_URL);
@@ -107,58 +48,13 @@ export default function CustomersPage() {
     loadCustomers();
   }, []);
 
-  const resetForm = () => {
-    setForm({
-      id: 0,
-      first: '',
-      last: '',
-      age: 0,
-      email: '',
-      address: { street: '', city: '', state: '', zipcode: '' },
-    });
-    setEditingId(null);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const payload = { ...form };
-    if (editingId === null) {
-      await fetch(API_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-    } else {
-      await fetch(`${API_URL}/${editingId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-    }
-    resetForm();
-    loadCustomers();
-  };
-
   const handleEdit = (id: number) => {
-    const customer = customers.find((c) => c.id === id);
-    if (!customer) return;
-    setForm({ ...customer, address: customer.address ?? { street: '', city: '', state: '', zipcode: '' } });
-    setEditingId(id);
+    router.push(`/customers/form?id=${id}`);
   };
 
   const handleDelete = async (id: number) => {
     await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
-    if (editingId === id) {
-      resetForm();
-    }
     loadCustomers();
-  };
-
-  const setAddress = (key: keyof Address, value: string) => {
-    setForm((prev) => ({
-      ...prev,
-      address: { ...(prev.address || { street: '', city: '', state: '', zipcode: '' }), [key]: value },
-    }));
   };
 
   const handleSort = (key: string) => {
@@ -206,109 +102,11 @@ export default function CustomersPage() {
   return (
     <div className={styles.container}>
       <h1>Customer Maintenance</h1>
-      <form onSubmit={handleSubmit} className={styles.form}>
-        <div className={styles.col}>
-          <label>
-            First
-            <input
-              value={form.first}
-              onChange={(e) => setForm({ ...form, first: e.target.value })}
-              required
-              maxLength={30}
-            />
-          </label>
-          <label>
-            Last
-            <input
-              value={form.last}
-              onChange={(e) => setForm({ ...form, last: e.target.value })}
-              required
-              maxLength={30}
-            />
-          </label>
-          <label>
-            Email
-            <input
-              type="email"
-              value={form.email}
-              onChange={(e) => setForm({ ...form, email: e.target.value })}
-              required
-              maxLength={30}
-            />
-          </label>
-          <label>
-            Age
-            <input
-              type="number"
-              value={form.age}
-              onChange={(e) => setForm({ ...form, age: Number(e.target.value) })}
-              min={0}
-              required
-            />
-          </label>
-        </div>
-        <div className={styles.col}>
-          <label>
-            Street
-            <input
-              value={form.address?.street ?? ''}
-              onChange={(e) => setAddress('street', e.target.value)}
-              required
-              maxLength={30}
-            />
-          </label>
-          <label>
-            City
-            <input
-              value={form.address?.city ?? ''}
-              onChange={(e) => setAddress('city', e.target.value)}
-              required
-              maxLength={30}
-            />
-          </label>
-          <div className={styles.row}>
-            <label>
-              State
-              <select
-                className={styles.stateSelect}
-                value={form.address?.state ?? ''}
-                onChange={(e) => setAddress('state', e.target.value)}
-                required
-              >
-                <option value="">Select...</option>
-                {STATES.map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label>
-              Zipcode
-              <input
-                value={form.address?.zipcode ?? ''}
-                onChange={(e) => setAddress('zipcode', e.target.value)}
-                required
-                maxLength={10}
-                className={styles.zipInput}
-              />
-            </label>
-          </div>
-        </div>
-        <div className={styles.formButtons}>
-          <button type="submit" className={styles.button}>
-            {editingId === null ? 'Add' : 'Update'}
-          </button>
-          <button
-            type="button"
-            onClick={resetForm}
-            className={`${styles.button} ${styles.cancelButton}`}
-          >
-            {editingId === null ? 'Reset' : 'Cancel'}
-          </button>
-        </div>
-      </form>
-
+      <div className={styles.tableHeader}>
+        <Link href="/customers/form" className={styles.newButton}>
+          New Customer
+        </Link>
+      </div>
       <div className={styles.tableContainer}>
         <table className={styles.table}>
           <thead>
@@ -334,8 +132,8 @@ export default function CustomersPage() {
                 <td>{c.address?.state}</td>
                 <td>{c.address?.zipcode}</td>
                 <td>
-                  <button onClick={() => handleEdit(c.id)}>Edit</button>
-                  <button onClick={() => handleDelete(c.id)}>Delete</button>
+                  <button className={styles.actionButton} onClick={() => handleEdit(c.id)}>Edit</button>
+                  <button className={styles.actionButton} onClick={() => handleDelete(c.id)}>Delete</button>
                 </td>
               </tr>
             ))}

--- a/version.md
+++ b/version.md
@@ -1,4 +1,9 @@
 # Version History
+## 2.0.46 - 2025-06-05
+- Split customer table and form into separate pages.
+- Added navigation buttons and cancel functionality.
+- Spaced action buttons in table.
+
 ## 2.0.45 - 2025-06-05
 - Documented dependency installation, lint, and test commands in README.
 


### PR DESCRIPTION
## Summary
- split customer table and form onto separate pages
- add navigation to new form page and cancel handling
- style buttons and add space between action buttons
- document version history

## Testing
- `npm run lint` in customer-app
- `npm run lint` in customer-api *(fails: ESLint couldn't find configuration)*
- `npm test` in customer-api

------
https://chatgpt.com/codex/tasks/task_e_684148982c7c832da0632a58cf37628c