### PR TITLE
Fix table scroll and height

### DIFF
--- a/customer-app/src/app/customers/page.module.css
+++ b/customer-app/src/app/customers/page.module.css
@@ -2,9 +2,9 @@
 # App: Customer CRUD Application
 # Package: customer-app
 # File: src/app/customers/page.module.css
-# Version: 2.0.47
+# Version: 2.0.48
 # Author: Bobwares
-# Date: 2025-06-05 07:44:19 UTC
+# Date: 2025-06-05 07:53:58 UTC
 # Description: CSS styles for the customer maintenance page.
 #
 */
@@ -106,7 +106,7 @@
   background-color: #ffffff;
   border: 1px solid #ccc;
   padding: 1rem;
-  max-height: 400px;
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -126,7 +126,7 @@
   position: sticky;
   top: 0;
   background-color: #ffffff;
-  z-index: 1;
+  z-index: 2;
 }
 
 .actionButton {

--- a/customer-app/src/app/customers/page.tsx
+++ b/customer-app/src/app/customers/page.tsx
@@ -1,9 +1,9 @@
 // App: Customer CRUD Application
 // Package: customer-app
 // File: src/app/customers/page.tsx
-// Version: 2.0.47
+// Version: 2.0.48
 // Author: Bobwares
-// Date: 2025-06-05 07:44:19 UTC
+// Date: 2025-06-05 07:53:58 UTC
 // Description: Customer table page with navigation to form page.
 //
 "use client";

--- a/version.md
+++ b/version.md
@@ -1,4 +1,8 @@
 # Version History
+## 2.0.48 - 2025-06-05
+- Expanded customer table to fill available page space.
+- Ensured scrolling rows disappear behind sticky header.
+
 ## 2.0.47 - 2025-06-05
 - Renamed first column header to "Name".
 - Made table header sticky when scrolling.


### PR DESCRIPTION
## Summary
- expand customer table to occupy remaining page space
- ensure scrolling rows disappear beneath sticky header
- document version 2.0.48

## Testing
- `npm run lint` in `customer-app`
- `npm run lint` in `customer-api` *(fails: ESLint config missing)*
- `npm test` in `customer-api`


------
https://chatgpt.com/codex/tasks/task_e_68414cc51cf4832db21d2867d49ddef0